### PR TITLE
Returning None when no DOSCAR is present

### DIFF
--- a/dfttopif/parsers/vasp.py
+++ b/dfttopif/parsers/vasp.py
@@ -21,7 +21,12 @@ class VaspParser(DFTParser):
         file_path = os.path.join(self._directory, 'CONTCAR')
         if os.path.isfile(file_path):
             return read_vasp(file_path)
-        else: return None
+
+        file_path = os.path.join(self._directory, 'POSCAR')
+        if os.path.isfile(file_path):
+            return read_vasp(file_path)
+
+        return None
         
     def get_cutoff_energy(self):
         # Open up the OUTCAR


### PR DESCRIPTION
Some databases don't save DOSCAR, for example [alloy database](http://alloy.phys.cmu.edu/)