### PR TITLE
Adding an entrypoint to use pif-dft as a dice converter

### DIFF
--- a/dfttopif/__init__.py
+++ b/dfttopif/__init__.py
@@ -166,3 +166,14 @@ def directory_to_pif(directory, verbose=0, quality_report=False):
             print(r.status_code)
 
     return chem
+
+def convert(files=None, **kwargs):
+    """
+    Wrap directory to pif as a dice extension
+    :param files: a list of files, should only have one file here
+    :param kwargs: any additional keyword arguments
+    :return: the created pif
+    """
+    assert len(files) == 1
+
+    return directory_to_pif(files[0], **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,15 @@ setup(
     url='https://github.com/CitrineInformatics/pif-dft',
     install_requires=[
         'ase',
-        'pypif',
+        'pypif>=1.1.6',
     ],
     extras_require={
         'report': ["requests"],
     },
     packages=find_packages(exclude=('tests', 'docs')),
+    entry_points={
+        'citrine.dice.converter': [
+            'dft = dfttopif'
+        ]
+    }
 )


### PR DESCRIPTION
This thin wrapper and entrypoint allow `directory_to_pif` to be called as a dice extension.