### PR TITLE
Adding the density to the VASP and PWSCF parsers

### DIFF
--- a/dfttopif/parsers/base.py
+++ b/dfttopif/parsers/base.py
@@ -1,6 +1,6 @@
 import os
 from collections import Counter
-from pypif.obj.common import Value, Property
+from pypif.obj.common import Value, Property, Scalar
 
 
 def Value_if_true(func):
@@ -106,6 +106,7 @@ class DFTParser(object):
             'Positions': 'get_positions',
             'Forces': 'get_forces',
             'Total force': 'get_total_force',
+            'Density': 'get_density',
             'OUTCAR': 'get_outcar',
         }
         
@@ -163,6 +164,12 @@ class DFTParser(object):
         counts = Counter(strc.get_chemical_symbols())
         return ''.join(k if counts[k]==1 else '%s%d'%(k,counts[k]) \
                 for k in sorted(counts))
+
+    def get_density(self):
+        """Compute the density from the output structure"""
+        strc = self.get_output_structure()
+        density = sum(strc.get_masses()) / strc.get_volume() * 1.660539040
+        return Property(scalars=Scalar(value=density), units="g/(cm^3)")
 
     def get_positions(self):
         strc = self.get_output_structure()

--- a/tests/parsers/test_pwscf.py
+++ b/tests/parsers/test_pwscf.py
@@ -31,6 +31,10 @@ class TestPWSCFParser(unittest.TestCase):
         self.assertEquals(2.2713025676424632, strc.cell[0][2])
         self.assertEquals(['F', 'Na'], strc.get_chemical_symbols())
         self.assertEquals('FNa', parser.get_composition())
+
+        # Test the density
+        self.assertAlmostEqual(2.975233747, parser.get_density().scalars[0].value)
+        self.assertEqual("g/(cm^3)", parser.get_density().units)
         
         cutoff = parser.get_cutoff_energy()
         self.assertEquals(50.0, cutoff.scalars[0].value)

--- a/tests/parsers/test_vasp.py
+++ b/tests/parsers/test_vasp.py
@@ -22,7 +22,11 @@ class TestVASPParser(unittest.TestCase):
         self.assertAlmostEquals(3.9088966983609255, strc.cell[1][1])
         self.assertEquals(['La','Mn','O','O','O'], strc.get_chemical_symbols())
         self.assertEquals('LaMnO3', parser.get_composition())
-        
+
+        # Test the density
+        self.assertEqual("g/(cm^3)", parser.get_density().units)
+        self.assertAlmostEqual(6.7238121, parser.get_density().scalars[0].value)
+
         res = parser.get_cutoff_energy()
         self.assertEquals(400, res.scalars[0].value)
         self.assertEquals('eV', res.units)


### PR DESCRIPTION
Computed by summing the masses and dividing by the cell volume.