### PR TITLE
Change API for 'If From' Method of Parsers

### DIFF
--- a/dfttopif/drivers.py
+++ b/dfttopif/drivers.py
@@ -4,6 +4,7 @@ import tarfile
 import shutil
 from dfttopif.parsers import VaspParser
 from dfttopif.parsers import PwscfParser
+from dfttopif.parsers.base import InvalidIngesterException
 from pypif.obj import *
 import json
 
@@ -110,17 +111,18 @@ def directory_to_pif(directory, verbose=0, quality_report=True, inline=True):
 
     # Look for the first parser compatible with the directory
     found_parser = False
-    for possible_parser in [VaspParser, PwscfParser]:
+    for possible_parser in [PwscfParser, VaspParser]:
         try:
             parser = possible_parser(directory)
             found_parser = True
-        except Exception:
+            break
+        except InvalidIngesterException:
             # Constructors fail when they cannot find appropriate files
             pass
     if not found_parser:
         raise Exception('Directory is not in correct format for an existing parser')
     if verbose > 0:
-        print("Found a %s directory", parser.get_name())
+        print("Found a %s directory" % parser.get_name())
         
     # Get information about the chemical system
     chem = ChemicalSystem()

--- a/dfttopif/drivers.py
+++ b/dfttopif/drivers.py
@@ -109,15 +109,15 @@ def directory_to_pif(directory, verbose=0, quality_report=True, inline=True):
     '''
 
     # Look for the first parser compatible with the directory
-    foundParser = False
+    found_parser = False
     for possible_parser in [VaspParser, PwscfParser]:
         try:
             parser = possible_parser(directory)
-            if parser.test_if_from(directory):
-                foundParser = True
-                break
-        except: pass
-    if not foundParser:
+            found_parser = True
+        except Exception:
+            # Constructors fail when they cannot find appropriate files
+            pass
+    if not found_parser:
         raise Exception('Directory is not in correct format for an existing parser')
     if verbose > 0:
         print("Found a %s directory", parser.get_name())

--- a/dfttopif/drivers.py
+++ b/dfttopif/drivers.py
@@ -122,7 +122,7 @@ def directory_to_pif(directory, verbose=0, quality_report=True, inline=True):
     if not found_parser:
         raise Exception('Directory is not in correct format for an existing parser')
     if verbose > 0:
-        print("Found a %s directory" % parser.get_name())
+        print("Found a {} directory".format(parser.get_name()))
         
     # Get information about the chemical system
     chem = ChemicalSystem()

--- a/dfttopif/parsers/abinit.py
+++ b/dfttopif/parsers/abinit.py
@@ -4,6 +4,7 @@ import glob
 from ase.calculators.abinit import Abinit
 from pypif.obj.common import Value, Property, Scalar
 
+
 class AbinitParser(DFTParser):
     '''
     Parser for ABINIT calculations
@@ -12,6 +13,7 @@ class AbinitParser(DFTParser):
 
     def __init__(self, directory):
         # Check whether any file has as name ABINIT in the file in the first two lines
+        super(AbinitParser, self).__init__(directory)
         files = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
         is_abinit = False
         for f in files:

--- a/dfttopif/parsers/abinit.py
+++ b/dfttopif/parsers/abinit.py
@@ -1,4 +1,4 @@
-from .base import DFTParser
+from .base import DFTParser, InvalidIngesterException
 import os
 import glob
 from ase.calculators.abinit import Abinit
@@ -25,7 +25,7 @@ class AbinitParser(DFTParser):
             except:
                 continue
         if not is_abinit:
-            raise Exception('No Abinit files found')
+            raise InvalidIngesterException('No Abinit files found')
     
     def get_name(self): return "ABINIT"
 

--- a/dfttopif/parsers/abinit.py
+++ b/dfttopif/parsers/abinit.py
@@ -9,22 +9,24 @@ class AbinitParser(DFTParser):
     Parser for ABINIT calculations
     '''
     _label = None
-    
-    def get_name(self): return "ABINIT"
-    
-    def test_if_from(self, directory):
+
+    def __init__(self, directory):
         # Check whether any file has as name ABINIT in the file in the first two lines
         files = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
+        is_abinit = False
         for f in files:
             try:
                 with open(os.path.join(directory, f), 'r') as fp:
                     for line in [fp.readline(), fp.readline()]:
                         if "ABINIT" in line:
-                            return True
+                            is_abinit = True
             except:
                 continue
-        return False
-        
+        if not is_abinit:
+            raise Exception('No Abinit files found')
+    
+    def get_name(self): return "ABINIT"
+
     def _get_label(self):
         '''Find the label for the output files 
          for this calculation

--- a/dfttopif/parsers/base.py
+++ b/dfttopif/parsers/base.py
@@ -47,26 +47,11 @@ class DFTParser(object):
         
         Input:
             directory - String, path to a directory of output files
+        Raises:
+            Exception - If parser cannot find needed files
         '''
-        
-        # Sanity check: Make sure the format is correct
-        if not self.test_if_from(directory):
-            raise Exception('Files in directory inconsistent with this format')
-            
+
         self._directory = directory
-      
-    @classmethod
-    def test_if_from(self, directory):
-        '''Test whether a directory of output files
-        seems like it is from this DFT code.
-        
-        Input:
-            directory - String, path to a directory of output files
-        Returns: 
-            boolean, whether directory was created by this code
-        '''
-        
-        raise NotImplementedError
         
     def get_setting_functions(self):
         '''Get a dictionary containing the names of methods

--- a/dfttopif/parsers/base.py
+++ b/dfttopif/parsers/base.py
@@ -9,6 +9,10 @@ def Value_if_true(func):
     return lambda x: Value() if func(x) == True else None
 
 
+class InvalidIngesterException(ValueError):
+    pass
+
+
 class DFTParser(object):
     '''Base class for all tools to parse a directory of output files from a DFT Calculation
     
@@ -48,7 +52,7 @@ class DFTParser(object):
         Input:
             directory - String, path to a directory of output files
         Raises:
-            Exception - If parser cannot find needed files
+            Par - If parser cannot find needed files
         '''
 
         self._directory = directory

--- a/dfttopif/parsers/pwscf.py
+++ b/dfttopif/parsers/pwscf.py
@@ -18,17 +18,17 @@ class PwscfParser(DFTParser):
         parser = PwscfStdOutputParser()
 
         # Look for appropriate files
-        try:
-            self.inputf = self.outputf = None
-            files = [f for f in os.listdir(self._directory) if os.path.isfile(os.path.join(directory, f))]
-            for f in files:
+        self.inputf = self.outputf = None
+        files = [f for f in os.listdir(self._directory) if os.path.isfile(os.path.join(directory, f))]
+        for f in files:
+            try:
                 if self._get_line('Program PWSCF', f, basedir=self._directory, return_string=False):
                     self.outputf = f
                 elif self._get_line('&control', f, basedir=self._directory, return_string=False, case_sens=False):
                     self.inputf = f
-        except Exception as e:
-            raise InvalidIngesterException('Parser failed due to: ' + str(e))
-        print(self.inputf, self.outputf)
+            except Exception as e:
+                pass
+
         if self.inputf is None:
             raise InvalidIngesterException('Failed to find input file')
         if self.outputf is None:

--- a/dfttopif/parsers/pwscf.py
+++ b/dfttopif/parsers/pwscf.py
@@ -26,7 +26,7 @@ class PwscfParser(DFTParser):
                     self.outputf = f
                 elif self._get_line('&control', f, basedir=self._directory, return_string=False, case_sens=False):
                     self.inputf = f
-            except Exception as e:
+            except UnicodeDecodeError as e:
                 pass
 
         if self.inputf is None:

--- a/dfttopif/parsers/pwscf.py
+++ b/dfttopif/parsers/pwscf.py
@@ -15,6 +15,21 @@ class PwscfParser(DFTParser):
         super(PwscfParser, self).__init__(directory)
         self.settings = {}
         parser = PwscfStdOutputParser()
+
+        # Look for appropriate files
+        self.inputf = self.outputf = None
+        files = [f for f in os.listdir(self._directory) if os.path.isfile(os.path.join(directory, f))]
+        for f in files:
+            if self._get_line('Program PWSCF', f, basedir=self._directory, return_string=False):
+                self.outputf = f
+            elif self._get_line('&control', f, basedir=self._directory, return_string=False, case_sens=False):
+                self.inputf = f
+        if self.inputf is None:
+            raise Exception('Failed to find input file')
+        if self.outputf is None:
+            raise Exception('Failed to find output file')
+
+        # Read in the settings
         with open(os.path.join(directory, self.outputf), "r") as f:
             for line in parser.parse(f.readlines()):
                 self.settings.update(line)
@@ -58,18 +73,6 @@ class PwscfParser(DFTParser):
                     raise Exception('%s not found in %s'%(' & '.join(search_string),os.path.join(basedir, search_file)))
                 else: return False
         else: raise Exception('%s file does not exist'%os.path.join(basedir, search_file))
-    
-    def test_if_from(self, directory):
-        '''Look for PWSCF input and output files'''
-        self.inputf = self.outputf = ''
-        files = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
-        for f in files:
-            if self._get_line('Program PWSCF', f, basedir=directory, return_string=False):
-                self.outputf = f
-            elif self._get_line('&control', f, basedir=directory, return_string=False, case_sens=False):
-                self.inputf = f
-            if self.inputf and self.outputf: return True
-        return False
 
     def get_version_number(self):
         '''Determine the version number from the output'''

--- a/dfttopif/parsers/vasp.py
+++ b/dfttopif/parsers/vasp.py
@@ -1,6 +1,6 @@
 from pypif.obj import Property, Scalar
 
-from .base import DFTParser, Value_if_true
+from .base import DFTParser, Value_if_true, InvalidIngesterException
 import os
 from ase.calculators.vasp import Vasp
 from ase.io.vasp import read_vasp, read_vasp_out
@@ -18,7 +18,7 @@ class VaspParser(DFTParser):
         super(VaspParser, self).__init__(directory)
 
         if not 'OUTCAR' in os.listdir(self._directory):
-            raise Exception('OUTCAR not found')
+            raise InvalidIngesterException('OUTCAR not found')
 
     def get_name(self): return "VASP"
         

--- a/dfttopif/parsers/vasp.py
+++ b/dfttopif/parsers/vasp.py
@@ -14,11 +14,13 @@ class VaspParser(DFTParser):
     Parser for VASP calculations
     '''
 
+    def __init__(self, directory):
+        super(VaspParser, self).__init__(directory)
+
+        if not 'OUTCAR' in os.listdir(self._directory):
+            raise Exception('OUTCAR not found')
+
     def get_name(self): return "VASP"
-    
-    def test_if_from(self, directory):
-        # Check whether it has an INCAR file
-        return os.path.isfile(os.path.join(directory, 'OUTCAR'))
         
     def get_output_structure(self):
         self.atoms = read_vasp_out(os.path.join(self._directory, 'OUTCAR'))


### PR DESCRIPTION
Turns out that `test_if_from` is not used by the driver directly. It is called after instantiating the parser class, and the constructor raises an exception if `test_if_from` fails. So, there really isn't a point in having `test_if_from` as a separate operation. It never gets called by classes that use this parser because the parser fails to instantiate before you call this function.

I had originally designed this method as a static operation to check whether a directory of files was likely generated by a certain code, but it seems now that just having the constructor for a parser fail if the files are not as expected serves the same purpose. Even if we implemented `test_if_from` as static methods (only the VASP parser has a static method), I doubt we gain much. We have to do complicated logic to determine whether a directory contains data of a certain type (see PWSCF). It seems then we'd have to call that logic twice: once for checking if you can make a parser, and again when making the parser (as you'll have to determine which files are the inputs/outputs to both check if a directory contains these files and extracting metadata from those classes).

Consequently, I've moved the logic from `test_if_from` inside the constructors and simplified the driver.

Sorry for the long PR message. Do you agree?