### PR TITLE
Made detection of NION, NKPTS more robust

### DIFF
--- a/dfttopif/parsers/vasp.py
+++ b/dfttopif/parsers/vasp.py
@@ -148,10 +148,10 @@ class VaspParser(DFTParser):
         with open(self.outcar) as fp:
             #store the number of atoms and number of irreducible K-points
             for line in fp:
-                if "NIONS" in line:
+                if "number of ions     NIONS =" in line:
                     words = line.split()
                     NI = int(words[11])
-                elif "NKPTS" in line:
+                elif "k-points           NKPTS =" in line:
                     words = line.split()
                     NIRK = float(words[3])
             #check if the number of k-points was reduced by VASP if so, sum all the k-points weight


### PR DESCRIPTION
There is a VASP warning message with `NIONS` in it. The VASP parser was failing because it only looked for the word `NIONS`. This change makes the parser robust to the appearance of this warning message and, while I was at it, other messages that contain `NION` or `NKPTS`.