### PR TITLE
Moved VASP-related settings to VASP parser

### DIFF
--- a/dfttopif/parsers/base.py
+++ b/dfttopif/parsers/base.py
@@ -81,9 +81,7 @@ class DFTParser(object):
             'Spin-Orbit Coupling':'uses_SOC',
             'DFT+U':'get_U_settings',
             'vdW Interactions':'get_vdW_settings',
-            'Pseudopotentials':'get_pp_name',
-            'INCAR':'get_incar',
-            'POSCAR':'get_poscar',
+            'Pseudopotentials':'get_pp_name'
         }
         
     def get_result_functions(self):
@@ -104,7 +102,6 @@ class DFTParser(object):
             'Forces': 'get_forces',
             'Total force': 'get_total_force',
             'Density': 'get_density',
-            'OUTCAR': 'get_outcar',
             'Total magnetization': 'get_total_magnetization',
             'Stresses': 'get_stresses'
         }

--- a/dfttopif/parsers/vasp.py
+++ b/dfttopif/parsers/vasp.py
@@ -41,6 +41,21 @@ class VaspParser(DFTParser):
         self.eignval = _find_file('EIGNVAL')
 
     def get_name(self): return "VASP"
+
+    def get_setting_functions(self):
+        settings = super(VaspParser, self).get_setting_functions()
+        settings.update({
+            'INCAR': 'get_incar',
+            'POSCAR': 'get_poscar',
+        })
+        return settings
+
+    def get_result_functions(self):
+        outputs = super(VaspParser, self).get_result_functions()
+        outputs.update({
+            'OUTCAR': 'get_outcar',
+        })
+        return outputs
         
     def get_output_structure(self):
         self.atoms = read_vasp_out(self.outcar)


### PR DESCRIPTION
I noticed that the get OUTCAR/POSCAR/INCAR functions are defined in the base parser class. This PR moves the definition of those functions to the Vasp parser class.