### PR TITLE
Put an upper bound on the ase version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Python library for extracting the input settings and results from Density Func
 Requirements
 ------------
 
-Python 2.7 or >=3.4, with dependencies listed in [requirements.txt](https://github.com/CitrineInformatics/pif-dft/blob/master/requirements.txt)
+Python 2.7 or >=3.5, with dependencies listed in [requirements.txt](https://github.com/CitrineInformatics/pif-dft/blob/master/requirements.txt)
 
 Installation
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ase==3.16.2
+ase==3.17.0
 numpy
 requests
 flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ase
+ase==3.16.2
 numpy
 requests
 flask

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description='Library for parsing Density Functional Theory calculations',
     url='https://github.com/CitrineInformatics/pif-dft',
     install_requires=[
-        'ase',
+        'ase<=3.16.2',
         'pypif>=2.0.1,<3',
         'dftparse>=0.2.1'
     ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description='Library for parsing Density Functional Theory calculations',
     url='https://github.com/CitrineInformatics/pif-dft',
     install_requires=[
-        'ase<=3.16.2',
+        'ase<=3.17.0',
         'pypif>=2.0.1,<3',
         'dftparse>=0.2.1'
     ],


### PR DESCRIPTION
ASE stopped supporting python 2 in release [3.18.0](https://pypi.org/project/ase/3.18.0/).  This repository still does, so we can't use that or newer versions of ASE.

Travis's build matrix for python version seems to be struggling with 3.4 all of a sudden, so let's remove that.